### PR TITLE
minor: fix a mispell in warning message

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
@@ -46,7 +46,6 @@ abstract class RainbowHighlightVisitor : HighlightVisitor {
 
                 val notification = group.createNotification(
                     "Rainbowify big files is disabled by default",
-                    "File with line count > 1000 will not rainbowify be default. If you still want to rainbowify it, please config it in <b>Settings > Other Settings > Rainbow Brackets > Do NOT rainbowify big files</b>",
                     NotificationType.INFORMATION
                 )
 


### PR DESCRIPTION
be default -> by default